### PR TITLE
feat: Add export to CSV and JSON functionality

### DIFF
--- a/all_in_one_tool/Cargo.lock
+++ b/all_in_one_tool/Cargo.lock
@@ -150,6 +150,7 @@ name = "all_in_one_tool"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "csv",
  "humantime",
  "humantime-serde",
  "id3",
@@ -1132,6 +1133,27 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/all_in_one_tool/Cargo.toml
+++ b/all_in_one_tool/Cargo.toml
@@ -18,6 +18,7 @@ mp4ameta = "0.13.0"
 slint = "1.5.1"
 rfd = "0.14.1"
 png = "0.17.16"
+csv = "1.3.0"
 
 [build-dependencies]
 slint-build = "1.5.1"

--- a/all_in_one_tool/src/main.rs
+++ b/all_in_one_tool/src/main.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use db::Database;
 use slint::{Model, VecModel};
 use std::rc::Rc;
+use std::cell::RefCell;
 use std::thread;
 use rfd::FileDialog;
 
@@ -74,11 +75,48 @@ fn format_metadata_details(metadata: &FileMetadata) -> String {
     details
 }
 
+use std::path::Path;
+use std::fs::File;
+
+fn export_to_json(results: &[FileMetadata], path: &Path) -> Result<()> {
+    let file = File::create(path)?;
+    serde_json::to_writer_pretty(file, results)?;
+    Ok(())
+}
+
+#[derive(serde::Serialize)]
+struct CsvRecord<'a> {
+    path: &'a str,
+    size: u64,
+    modified: String,
+    specific_metadata: String,
+}
+
+fn export_to_csv(results: &[FileMetadata], path: &Path) -> Result<()> {
+    let mut writer = csv::Writer::from_path(path)?;
+
+    for metadata in results {
+        let specific_metadata_json = serde_json::to_string(&metadata.specific)?;
+
+        let record = CsvRecord {
+            path: &metadata.path,
+            size: metadata.size,
+            modified: humantime::format_rfc3339(metadata.modified).to_string(),
+            specific_metadata: specific_metadata_json,
+        };
+        writer.serialize(record)?;
+    }
+
+    writer.flush()?;
+    Ok(())
+}
+
 
 fn main() -> Result<()> {
     let app = AppWindow::new()?;
 
     let db = Rc::new(Database::new("index.db")?);
+    let full_search_results = Rc::new(RefCell::new(Vec::<FileMetadata>::new()));
 
     let app_weak = app.as_weak();
     app.on_select_directory(move || {
@@ -106,6 +144,7 @@ fn main() -> Result<()> {
     });
 
     let db_clone_for_search = db.clone();
+    let full_search_results_clone = full_search_results.clone();
     let app_weak = app.as_weak();
     app.on_search(move |query| {
         if let Some(app) = app_weak.upgrade() {
@@ -114,6 +153,8 @@ fn main() -> Result<()> {
                 eprintln!("Error searching metadata: {}", e);
                 vec![]
             });
+
+            *full_search_results_clone.borrow_mut() = results.clone();
 
             let file_infos: Vec<FileInfo> = results
                 .into_iter()
@@ -128,9 +169,9 @@ fn main() -> Result<()> {
     });
 
     let db_clone_for_select_file = db.clone();
-    let app_weak = app.as_weak();
+    let app_weak_for_select = app.as_weak();
     app.on_file_selected(move |index| {
-        if let Some(app) = app_weak.upgrade() {
+        if let Some(app) = app_weak_for_select.upgrade() {
             let db = db_clone_for_select_file.clone();
             if let Some(file_info) = app.get_search_results().row_data(index as usize) {
                 if let Ok(metadata) = db.get_metadata_by_path(&file_info.path) {
@@ -138,6 +179,36 @@ fn main() -> Result<()> {
                     app.set_selected_file_details(details.into());
                 } else {
                     app.set_selected_file_details("Could not retrieve details.".into());
+                }
+            }
+        }
+    });
+
+    let app_weak_for_export = app.as_weak();
+    let full_search_results_clone_for_export = full_search_results.clone();
+    app.on_export_results(move || {
+        if let Some(app) = app_weak_for_export.upgrade() {
+            let results = full_search_results_clone_for_export.borrow();
+            if results.is_empty() {
+                app.set_selected_file_details("No results to export.".into());
+                return;
+            }
+
+            if let Some(path) = FileDialog::new()
+                .add_filter("JSON", &["json"])
+                .add_filter("CSV", &["csv"])
+                .save_file()
+            {
+                let extension = path.extension().and_then(|s| s.to_str()).unwrap_or("");
+                let result = match extension {
+                    "json" => export_to_json(&results, &path),
+                    "csv" => export_to_csv(&results, &path),
+                    _ => Err(anyhow::anyhow!("Unsupported file extension")),
+                };
+
+                match result {
+                    Ok(_) => app.set_selected_file_details(format!("Exported to {}", path.display()).into()),
+                    Err(e) => app.set_selected_file_details(format!("Export failed: {}", e).into()),
                 }
             }
         }

--- a/all_in_one_tool/src/ui/main.slint
+++ b/all_in_one_tool/src/ui/main.slint
@@ -12,6 +12,7 @@ export component AppWindow inherits Window {
     callback select_directory();
     callback search(string);
     callback file_selected(int);
+    callback export_results();
 
 
     title: "File Searcher";
@@ -26,6 +27,7 @@ export component AppWindow inherits Window {
             spacing: 5px;
             Button { text: "Select Directory..."; clicked => { select_directory(); } }
             search_input := LineEdit { placeholder-text: "Search..."; edited(text) => { search(text); } }
+            Button { text: "Export..."; clicked => { export_results(); } }
         }
 
        search_list_view := ListView {


### PR DESCRIPTION
This commit introduces a feature that allows users to export search results to either JSON or CSV format.

- Adds an 'Export...' button to the UI.
- Implements the logic to handle file saving via a native dialog.
- Serializes search results to JSON, preserving the full data structure.
- Serializes search results to a flattened CSV format for ease of use in spreadsheet applications.